### PR TITLE
docs: add S3 model artifact workflow

### DIFF
--- a/openshift-ai-demos/README.md
+++ b/openshift-ai-demos/README.md
@@ -46,6 +46,10 @@ oc new-project <your-project> || oc project <your-project>
 oc apply -f shared/s3-secret.yaml
 ```
 
+For model-serving demos, download and upload the required model artifacts before
+applying the InferenceService manifests. See the
+[S3 model artifact workflow](model-serving/README.md#upload-model-artifacts-to-s3).
+
 ## Available Demos
 
 ### Model Serving

--- a/openshift-ai-demos/model-serving/README.md
+++ b/openshift-ai-demos/model-serving/README.md
@@ -43,7 +43,93 @@ s3://<bucket-name>/
         └── [model files]
 ```
 
-Update the `storageUri` in each model's YAML file to match your S3 bucket structure.
+Update the `spec.predictor.model.storage.path` value in each model's YAML file
+to match your S3 bucket structure.
+
+---
+
+## Upload Model Artifacts to S3
+
+The model-serving manifests read model files from the bucket configured in
+[`s3-secret.yaml`](/openshift-ai-demos/shared/s3-secret.yaml). Download model
+artifacts locally, upload them to the matching `models/<model-name>/` prefix,
+then verify that the files are visible before applying an InferenceService.
+
+### 1. Configure the S3 CLI
+
+Install and configure the AWS CLI for your S3-compatible storage provider:
+
+```bash
+aws configure
+```
+
+If you use a non-AWS endpoint, set it once for the commands in this guide:
+
+```bash
+export S3_ENDPOINT_URL="https://<s3-endpoint>"
+
+S3_ARGS=()
+if [ -n "${S3_ENDPOINT_URL:-}" ]; then
+  S3_ARGS+=(--endpoint-url "$S3_ENDPOINT_URL")
+fi
+```
+
+### 2. Download model artifacts
+
+Download each model into a local staging directory. For Hugging Face models, one
+common option is `huggingface-cli`:
+
+```bash
+mkdir -p /tmp/rhoai-models
+
+huggingface-cli download microsoft/Phi-3-mini-4k-instruct \
+  --local-dir /tmp/rhoai-models/phi-3-mini-4k-instruct \
+  --local-dir-use-symlinks False
+```
+
+Repeat the download for any additional model used by a demo.
+
+### 3. Upload artifacts to the bucket
+
+Upload the local model directory to the prefix referenced by the demo manifest:
+
+```bash
+aws s3 sync /tmp/rhoai-models/phi-3-mini-4k-instruct \
+  s3://<bucket-name>/models/phi-3-mini-4k-instruct \
+  "${S3_ARGS[@]}"
+```
+
+For the included safety model manifest, use the same pattern with the matching
+prefix:
+
+```bash
+aws s3 sync /tmp/rhoai-models/granite-guardian-hap-125m \
+  s3://<bucket-name>/models/granite-guardian-hap-125m \
+  "${S3_ARGS[@]}"
+```
+
+### 4. Verify uploaded artifacts
+
+List the target prefix and confirm that model files such as configuration,
+tokenizer, and weight files are present:
+
+```bash
+aws s3 ls s3://<bucket-name>/models/phi-3-mini-4k-instruct/ \
+  --recursive \
+  "${S3_ARGS[@]}"
+```
+
+The prefix after `models/` must match the `spec.predictor.model.storage.path`
+value in the InferenceService YAML. For example:
+
+```yaml
+storage:
+  key: s3-creds
+  path: models/phi-3-mini-4k-instruct
+```
+
+After the files are present and the `s3-creds` secret is applied in your data
+science project namespace, deploy the model manifest with `oc apply`.
 
 ---
 


### PR DESCRIPTION
## Summary
- documents how to download model artifacts locally before serving
- adds `aws s3 sync` upload examples for the existing model storage prefixes
- explains how to verify uploaded artifacts and match them to `spec.predictor.model.storage.path`

## Validation
- `git diff --check`

Closes #22