### PR TITLE
Add embedding model serving demo

### DIFF
--- a/openshift-ai-demos/README.md
+++ b/openshift-ai-demos/README.md
@@ -32,7 +32,10 @@ NAME          READY   REASON
 default-dsc   True   
 ```
 
-### 3. S3 Storage
+### 3. S3 Storage *(required based on use case)*
+
+> **Note:** S3 storage is required for demos that use S3-based model serving or store data in object storage (e.g. AutoRAG, document ingestion pipelines). If you are only serving models downloaded directly into a PVC, you can skip this step. Refer to [model storage options](model-serving/README.md#model-storage-options) for details.
+
 Update [`s3-secret.yaml`](shared/s3-secret.yaml) with your credentials:
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`

--- a/openshift-ai-demos/model-serving/README.md
+++ b/openshift-ai-demos/model-serving/README.md
@@ -2,16 +2,6 @@
 
 Deploy and serve models on Red Hat OpenShift AI using KServe InferenceService.
 
-
----
-
-## Prerequisites
-
-Before deploying models, complete the setup steps described in the [OpenShift AI README](/openshift-ai-demos/README.md#getting-started):
-
-1. Configure `DSCInitialization` and `DataScienceCluster`
-2. Create the S3 secret with your object storage credentials
-
 ---
 
 ## Available Model Categories
@@ -23,6 +13,13 @@ Deploy and serve Large Language Models (LLMs) and other generative AI models on 
 
 ---
 
+### Embedding Models
+Deploy and serve embedding models for vector search, semantic search, and RAG pipelines on Red Hat OpenShift AI.
+
+[→ Explore Embedding Models](embedding-models/)
+
+---
+
 ### Safety Models
 Deploy content moderation, guardrails, and safety detection models on Red Hat OpenShift AI.
 
@@ -30,9 +27,11 @@ Deploy content moderation, guardrails, and safety detection models on Red Hat Op
 
 ---
 
-## S3 Model Storage
+## Model Storage Options
 
-Models must be stored in your S3-compatible object storage with the following structure:
+### Option 1: S3 Object Storage
+
+Models stored in S3-compatible object storage with the following structure:
 
 ```
 s3://<bucket-name>/
@@ -43,7 +42,54 @@ s3://<bucket-name>/
         └── [model files]
 ```
 
-Update the `storageUri` in each model's YAML file to match your S3 bucket structure.
+Update the `storage` section in each model's YAML file to match your S3 bucket structure:
+
+```yaml
+storage:
+  key: s3-creds
+  path: models/<model-name>
+```
+
+---
+
+### Option 2: PVC (HuggingFace Download)
+
+Download models directly from HuggingFace into a PersistentVolumeClaim using the  [model-downloader.yaml](shared/model-download.yaml). This is an alternative to S3 when object storage is not available.
+
+**Download a model:**
+```bash
+export NAMESPACE=<your-project>
+export MODEL_REPO=<hf-org>/<hf-model-name>   # e.g. ibm-granite/granite-embedding-125m-english
+export MODEL_NAME=<model-name>                # must be lowercase RFC 1123 (e.g. prompt-guard, not Prompt-Guard)
+export STORAGE_SIZE=5Gi
+export STORAGE_CLASS=<your-storage-class>
+export HF_TOKEN=<your-hf-token>               # optional, needed for private/gated models
+
+envsubst '${MODEL_NAME},${NAMESPACE},${STORAGE_SIZE},${STORAGE_CLASS},${MODEL_REPO},${HF_TOKEN}' \
+  < model-serving/shared/model-download.yaml | oc apply -f -
+```
+
+**Monitor the download:**
+```bash
+oc logs -f ${MODEL_NAME}-downloader
+```
+
+**Verify files after download:**
+```bash
+oc run verify --image=registry.access.redhat.com/ubi9/python-312:9.8-1783442686 \
+  --restart=Never --rm -it \
+  --overrides='{"spec":{"securityContext":{"runAsUser":1000,"fsGroup":1000},"containers":[{"name":"verify","image":"registry.access.redhat.com/ubi9/python-312:9.8-1783442686","command":["ls","-lh","/mnt/models/'"$MODEL_NAME"'/"],"volumeMounts":[{"mountPath":"/mnt/models","name":"v"}]}],"volumes":[{"name":"v","persistentVolumeClaim":{"claimName":"'"$MODEL_NAME"'-pvc"}}]}}'
+```
+
+**Clean up downloader pod:**
+```bash
+oc delete pod ${MODEL_NAME}-downloader
+```
+
+**Reference the PVC in your InferenceService:**
+```yaml
+storageUri: pvc://<model-name>-pvc/<model-name>
+```
 
 ---
 
@@ -55,11 +101,17 @@ Update the `storageUri` in each model's YAML file to match your S3 bucket struct
 - Check pod logs: `oc logs <predictor-pod-name>`
 - Verify S3 endpoint is accessible from cluster
 
+**PVC download fails:**
+- Check downloader pod logs: `oc logs ${MODEL_NAME}-downloader`
+- Ensure `HF_TOKEN` is set for private/gated models
+- Verify storage class exists: `oc get storageclass`
+
 **Insufficient resources:**
 - Adjust resource limits in YAML files
 - Verify cluster capacity: `oc describe nodes`
 - Check if nodes have required CPU/memory available
 
+---
 
 ## Resources
 

--- a/openshift-ai-demos/model-serving/embedding-models/README.md
+++ b/openshift-ai-demos/model-serving/embedding-models/README.md
@@ -1,0 +1,18 @@
+# Embedding Models
+
+Embedding models convert text into dense numerical vectors (embeddings) that capture semantic meaning. These embeddings enable applications such as Retrieval-Augmented Generation (RAG), semantic search, and vector databases by allowing text to be compared based on meaning rather than exact keywords.
+
+This demo shows how to deploy and serve embedding models on Red Hat OpenShift AI using vLLM. It provides an example deployment for serving embedding models and generating vector embeddings through a scalable and efficient inference service.
+
+---
+
+## Available Runtimes
+
+### vLLM Runtime
+High-performance inference engine supporting embedding models via the pooling runner.
+
+**Available Models:**
+- Granite Embedding 125M English
+- BGE-M3
+
+[→ View vLLM deployment guide](vllm/)

--- a/openshift-ai-demos/model-serving/embedding-models/vllm/README.md
+++ b/openshift-ai-demos/model-serving/embedding-models/vllm/README.md
@@ -1,0 +1,330 @@
+# vLLM Embedding Runtime
+
+Deploy and serve embedding models with the vLLM runtime on Red Hat OpenShift AI using Persistent Volume Claims (PVCs) for model storage.
+
+This directory contains example deployments, testing instructions, and runtime configuration for serving embedding models with KServe and the OpenAI-compatible Embeddings API.
+
+---
+
+## Prerequisites
+
+> Complete the [Getting Started](/openshift-ai-demos/README.md#getting-started) steps before proceeding. Ensure KServe is in `Managed` state and `DataScienceCluster` is in `Ready` state.
+
+Before deploying a model, ensure you have:
+
+- The following tools installed:
+  - `oc`
+  - `curl`
+  - `jq`
+  - `envsubst`
+- A Hugging Face access token (`HF_TOKEN`) if the model requires authentication.
+
+1. Create a data science project:
+   ```bash
+   export NAMESPACE=<your-project>
+   oc new-project $NAMESPACE || oc project $NAMESPACE
+   ```
+
+2. Navigate to the OpenShift AI demos directory:
+   ```bash
+   cd ai-demos/openshift-ai-demos
+   ```
+
+3. Verify that a `StorageClass` is available for provisioning Persistent Volume Claims (PVCs):
+   ```bash
+   oc get storageclass
+   ```
+
+4. Create the vLLM CPU runtime:
+   ```bash
+   oc process -n redhat-ods-applications vllm-cpu-runtime-template | oc apply -f -
+   ```
+
+---
+
+## Deploy Embedding Models
+
+The following examples demonstrate how to deploy embedding models using the vLLM CPU runtime.
+
+For each model:
+
+- Download the model to a Persistent Volume Claim (PVC).
+- Deploy the corresponding InferenceService.
+- Verify that the deployment is ready.
+- Test the model using the OpenAI-compatible Embeddings API.
+
+
+### 1. Granite Embedding 125M English
+
+**Model:** [ibm-granite/granite-embedding-125m-english](https://huggingface.co/ibm-granite/granite-embedding-125m-english)  
+**Dimensions:** 768  
+**Max tokens:** 512  
+**Total size:** ~ 1GB  
+
+**Resource Requirements:**
+| Resource | Allocation |
+|---|---|
+| CPU | 8 cores |
+| Memory | 16Gi |
+| Storage | 2Gi PVC |
+
+**Download the model to a persistent volume:**
+  ```bash
+  export MODEL_REPO=ibm-granite/granite-embedding-125m-english
+  export MODEL_NAME=granite-embedding-125m-english
+  export STORAGE_SIZE=2Gi
+  export STORAGE_CLASS=$(oc get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+
+  envsubst '${MODEL_NAME},${NAMESPACE},${STORAGE_SIZE},${STORAGE_CLASS},${MODEL_REPO},${HF_TOKEN}' \
+    < model-serving/shared/model-download.yaml | oc apply -f -
+  ```
+
+> To monitor the download, verify the downloaded files, and clean up the downloader pod, see [PVC Model Storage](../../README.md#option-2-pvc-huggingface-download).
+
+**Deploy the model:**
+```bash
+oc apply -f model-serving/embedding-models/vllm/granite-125m-english.yaml
+```
+
+---
+
+### 2. BGE-M3
+
+**Model:** [BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3)  
+**Dimensions:** 1024  
+**Max tokens:** 8192  
+**Total size:** ~ 4.59GB
+
+**Resource Requirements:**
+| Resource | Allocation |
+|---|---|
+| CPU | 8 cores |
+| Memory | 16Gi |
+| Storage | 5Gi PVC |
+
+**Download the model to a persistent volume:**
+```bash
+export MODEL_REPO=BAAI/bge-m3
+export MODEL_NAME=bge-m3
+export STORAGE_SIZE=5Gi
+export STORAGE_CLASS=$(oc get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+
+envsubst '${MODEL_NAME},${NAMESPACE},${STORAGE_SIZE},${STORAGE_CLASS},${MODEL_REPO},${HF_TOKEN}' \
+  < model-serving/shared/model-download.yaml | oc apply -f -
+```
+
+> To monitor the download, verify the downloaded files, and clean up the downloader pod, see [PVC Model Storage](../../README.md#option-2-pvc-huggingface-download).
+
+**Deploy the model:**
+```bash
+oc apply -f model-serving/embedding-models/vllm/bge-m3.yaml
+```
+
+---
+
+### Verify the deployment
+
+```bash
+oc get inferenceservice
+
+oc get pods -w | grep predictor
+```
+
+---
+
+## Test the Model
+The examples below use the OpenAI-compatible Embeddings API exposed by the vLLM runtime.
+```bash
+ISVC=<inferenceservice-name>
+MODEL_URL=$(oc get inferenceservice $ISVC -o jsonpath='{.status.url}')
+MODEL_NAME=$(curl -sk $MODEL_URL/v1/models | jq -r '.data[0].id')
+```
+
+> **Security Note:** The `-k` flag disables SSL certificate verification. Only use in development/testing environments.
+
+### 1. List Models
+Lists all models currently served by the runtime.
+
+```bash
+curl -sk $MODEL_URL/v1/models | jq .
+```
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "bge-m3",
+      "object": "model",
+      "created": 1783575578,
+      "owned_by": "vllm",
+      "root": "/mnt/models",
+      "parent": null,
+      "max_model_len": 8192,
+      "permission": [
+        {
+          "id": "modelperm-ad65d9624eb9de03",
+          "object": "model_permission",
+          "created": 1783575578,
+          "allow_create_engine": false,
+          "allow_sampling": true,
+          "allow_logprobs": true,
+          "allow_search_indices": false,
+          "allow_view": true,
+          "allow_fine_tuning": false,
+          "organization": "*",
+          "group": null,
+          "is_blocking": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 2. Generate an Embedding
+Generate an embedding for a single text input using the OpenAI-compatible Embeddings API.
+
+```bash
+curl -sk $MODEL_URL/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"$MODEL_NAME\",\"input\":\"What is machine learning?\"}" | jq .
+```
+
+```json
+{
+  "id": "embd-bf25400d42e0341b",
+  "object": "list",
+  "created": 1783575634,
+  "model": "bge-m3",
+  "data": [
+    {
+      "index": 0,
+      "object": "embedding",
+      "embedding": [
+        -0.046485308557748795,
+        -0.022186171263456345,
+        -0.030788971111178398,
+        .
+        .
+        .
+        0.0047919112257659435,
+        0.02460099197924137,
+        0.007169000804424286
+      ]
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 7,
+    "total_tokens": 7,
+    "completion_tokens": 0,
+    "prompt_tokens_details": null
+  }
+}
+```
+
+### 3. Batch Input
+Generate embeddings for multiple text inputs in a single request.
+
+```bash
+curl -sk $MODEL_URL/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"$MODEL_NAME\",\"input\":[\"What is machine learning?\",\"How does RAG work?\",\"Explain vector search\"]}" \
+  | jq '[.data[] | {index: .index, dimensions: (.embedding | length)}]'
+```
+```json
+[
+  {
+    "index": 0,
+    "dimensions": 1024
+  },
+  {
+    "index": 1,
+    "dimensions": 1024
+  },
+  {
+    "index": 2,
+    "dimensions": 1024
+  }
+]
+```
+
+### 4. Check Embedding Dimensions
+Return the number of dimensions in the embedding vector.
+
+```bash
+curl -sk $MODEL_URL/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"$MODEL_NAME\",\"input\":\"test\"}" \
+  | jq '.data[0].embedding | length'
+```
+
+```json
+1024
+```
+
+### 5. Pooling API (vLLM native)
+vLLM's native pooling endpoint that returns the same embedding vectors as `/v1/embeddings` in a different response format.
+
+```bash
+curl -sk $MODEL_URL/pooling \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"$MODEL_NAME\",\"input\":\"What is machine learning?\"}" | jq .
+```
+
+```json
+{
+  "id": "pooling-9867716949c9d145",
+  "object": "list",
+  "created": 1783575818,
+  "model": "bge-m3",
+  "data": [
+    {
+      "index": 0,
+      "object": "pooling",
+      "data": [
+        -0.046485308557748795,
+        -0.022186171263456345,
+        -0.030788971111178398,
+        -0.0025280159898102283,
+        .
+        .
+        .
+        0.0047919112257659435,
+        0.02460099197924137,
+        0.007169000804424286
+      ]
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 7,
+    "total_tokens": 7,
+    "completion_tokens": 0,
+    "prompt_tokens_details": null
+  }
+}
+```
+
+---
+
+## vLLM Configuration Reference
+
+### Args
+
+| Argument | Description |
+|---|---|
+| `--served-model-name` | Model name exposed via the API (`/v1/models`). Clients use this to call the model. |
+| `--max-model-len` | Maximum context length (input plus generated tokens for generation models). Requests exceeding this limit are rejected. For embedding models, it limits the maximum input length. |
+| `--max-num-seqs` | Maximum number of sequences (requests) processed concurrently in a single iteration. |
+| `--dtype=bfloat16` | Weight precision. Uses half the memory of `float32` with minimal accuracy loss. |
+| `--disable-custom-all-reduce` | Disables custom CUDA all-reduce kernel |
+| `--trust-remote-code` | Allows loading custom model code from HuggingFace (needed for some models). |
+| `--gpu-memory-utilization` | Fraction of available memory that vLLM is allowed to use. On GPU deployments, it limits GPU VRAM used for model execution and the KV cache. On CPU deployments, it limits the fraction of system RAM that the CPU backend may use during initialization. |
+| `--hf-overrides` | Overrides the Hugging Face model configuration, such as enabling Matryoshka dimensions. |
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `VLLM_ENGINE_ITERATION_TIMEOUT_S` | Timeout in seconds for a single engine iteration. Set high for CPU inference (e.g. `1200`). |
+| `VLLM_CPU_KVCACHE_SPACE` | Amount of CPU memory (GB) reserved for the KV cache. |

--- a/openshift-ai-demos/model-serving/embedding-models/vllm/bge-m3.yaml
+++ b/openshift-ai-demos/model-serving/embedding-models/vllm/bge-m3.yaml
@@ -1,0 +1,47 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    modelFormat: vLLM
+    opendatahub.io/connection-path: models/bge-m3
+    opendatahub.io/model-type: generative
+    openshift.io/display-name: bge-m3
+    security.opendatahub.io/enable-auth: "false"
+    serving.kserve.io/deploymentMode: Standard
+  labels:
+    networking.kserve.io/visibility: exposed
+    opendatahub.io/dashboard: "true"
+  name: bge-m3
+spec:
+  predictor:
+    deploymentStrategy:
+      type: RollingUpdate
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      args:
+      - --gpu-memory-utilization=0.4
+      - --served-model-name=bge-m3
+      - --max-model-len=8192
+      - --max-num-seqs=16
+      - --dtype=bfloat16
+      - --disable-custom-all-reduce
+      - --trust-remote-code
+      env:
+      - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
+        value: "1200"
+      - name: VLLM_CPU_KVCACHE_SPACE
+        value: "16"
+      modelFormat:
+        name: vLLM
+      name: ""
+      resources:
+        limits:
+          cpu: "8"
+          memory: 16Gi
+        requests:
+          cpu: "8"
+          memory: 16Gi
+      runtime: vllm-cpu-runtime
+      storageUri: pvc://bge-m3-pvc/bge-m3
+    timeout: 1200

--- a/openshift-ai-demos/model-serving/embedding-models/vllm/granite-125m-english.yaml
+++ b/openshift-ai-demos/model-serving/embedding-models/vllm/granite-125m-english.yaml
@@ -1,0 +1,45 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    modelFormat: vLLM
+    opendatahub.io/connection-path: models/granite-embedding-125m-english
+    opendatahub.io/model-type: generative
+    openshift.io/display-name: granite-embeddings
+    security.opendatahub.io/enable-auth: "false"
+    serving.kserve.io/deploymentMode: Standard
+    serving.kserve.io/stop: "false"
+  labels:
+    networking.kserve.io/visibility: exposed
+    opendatahub.io/dashboard: "true"
+  name: granite-embeddings
+spec:
+  predictor:
+    automountServiceAccountToken: false
+    deploymentStrategy:
+      type: RollingUpdate
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      args:
+      - --hf-overrides={"is_matryoshka":true,"matryoshka_dimensions":[768]}
+      - --gpu-memory-utilization=0.4
+      - --served-model-name=granite-embedding
+      - --max-model-len=512
+      - --max-num-seqs=16
+      env:
+      - name: VLLM_CPU_KVCACHE_SPACE
+        value: "8"
+      modelFormat:
+        name: vLLM
+      name: ""
+      resources:
+        limits:
+          cpu: "8"
+          memory: 16Gi
+        requests:
+          cpu: "8"
+          memory: 16Gi
+      runtime: vllm-cpu-runtime
+      storageUri: pvc://granite-embedding-125m-english-pvc/granite-embedding-125m-english
+    timeout: 600

--- a/openshift-ai-demos/model-serving/shared/model-download.yaml
+++ b/openshift-ai-demos/model-serving/shared/model-download.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${MODEL_NAME}-pvc
+  namespace: ${NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${STORAGE_SIZE}
+  storageClassName: ${STORAGE_CLASS}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${MODEL_NAME}-downloader
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: downloader
+      image: registry.access.redhat.com/ubi9/python-312:9.8-1783442686
+      securityContext:
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop:
+            - ALL
+      command:
+        - sh
+        - -c
+        - |
+          set -e
+
+          pip install -q "huggingface_hub[hf_xet]==1.22.0" \
+            --extra-index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/
+
+          set -x
+          hf download $MODEL_REPO \
+            --local-dir /mnt/models/$MODEL_NAME
+          set +x
+
+          echo "Model downloaded successfully."
+      env:
+        - name: MODEL_REPO
+          value: "${MODEL_REPO}"
+        - name: MODEL_NAME
+          value: "${MODEL_NAME}"
+        - name: HF_TOKEN
+          value: "${HF_TOKEN}"
+      volumeMounts:
+        - name: model-storage
+          mountPath: /mnt/models
+  volumes:
+    - name: model-storage
+      persistentVolumeClaim:
+        claimName: ${MODEL_NAME}-pvc


### PR DESCRIPTION
Add a demo for deploying and serving embedding models using the vLLM runtime on Red Hat OpenShift AI.

Includes:

- Granite Embedding 125M English and BGE-M3 demos
- Model download and deployment using PVC-backed storage
- Inference examples for:
  - Listing models
  - Single and batch embeddings
  - Checking embedding dimensions
  - Native vLLM pooling API
- Deployment documentation and demo videos

fixes: https://github.com/IBM/ai-demos/issues/16